### PR TITLE
Sam/reshard provision

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
     
+    - name: Install packages for pcsc dep
+      run: sudo apt-get install -y libpcsclite-dev gengetopt
+      shell: bash
+      
     - name: Install Rust
       # The rust version should align with rust-toolchain.toml
       uses: dtolnay/rust-toolchain@e2d9ac80ead8661a2e202b02724382f7a4eb1e1d # 1.88.0

--- a/.github/workflows/stagex.yml
+++ b/.github/workflows/stagex.yml
@@ -29,6 +29,7 @@ jobs:
         target:
           - name: reshard_app
           - name: reshard_host
+          - name: reshard_provision
     steps:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "asn1-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure 0.12.6",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +254,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -230,6 +275,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bitvec"
@@ -322,9 +373,11 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
- "windows-link",
+ "wasm-bindgen",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -376,10 +429,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "console"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
+dependencies = [
+ "futures",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -476,15 +551,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
- "der_derive",
+ "der_derive 0.6.1",
  "flagset",
- "pem-rfc7468",
+ "pem-rfc7468 0.6.0",
  "zeroize",
 ]
 
@@ -495,7 +576,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive 0.7.3",
+ "flagset",
+ "pem-rfc7468 0.7.0",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -511,6 +609,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,14 +630,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
+dependencies = [
+ "console",
+ "shell-words",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -544,10 +684,10 @@ dependencies = [
  "borsh",
  "clap",
  "futures",
- "qos_core",
- "qos_crypto",
- "qos_nsm",
- "qos_p256",
+ "qos_core 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
+ "qos_crypto 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
+ "qos_nsm 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
+ "qos_p256 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
  "qos_test_primitives",
  "reshard_app",
  "reshard_host",
@@ -559,14 +699,40 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12844141594ad74185a926d030f3b605f6a903b4e3fec351f3ea338ac5b7637e"
 dependencies = [
  "der 0.6.1",
  "elliptic-curve 0.12.3",
- "rfc6979",
- "signature",
+ "rfc6979 0.3.1",
+ "signature 2.0.0",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.0.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -589,6 +755,8 @@ dependencies = [
  "generic-array 0.14.7",
  "group 0.12.1",
  "hkdf",
+ "pem-rfc7468 0.6.0",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
  "sec1 0.3.0",
  "subtle",
@@ -631,6 +799,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +844,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +872,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -712,10 +896,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "futures-sink"
@@ -738,6 +944,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -774,7 +981,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.4+wasi-0.2.4",
 ]
 
 [[package]]
@@ -925,7 +1144,7 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "prost",
- "qos_core",
+ "qos_core 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
  "tokio",
  "tonic",
 ]
@@ -1058,10 +1277,117 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -1129,10 +1455,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "log"
@@ -1168,6 +1515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,7 +1536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -1207,11 +1560,21 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset",
  "pin-utils",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1237,6 +1600,24 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -1293,6 +1674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1302,6 +1684,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1318,13 +1709,35 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2",
+]
+
+[[package]]
+name = "p256"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49c124b3cbce43bcbac68c58ec181d98ed6cc7e6d0aa7c3ba97b2563410b0e55"
 dependencies = [
- "ecdsa",
+ "ecdsa 0.15.1",
  "elliptic-curve 0.12.3",
- "primeorder",
+ "primeorder 0.12.1",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
+dependencies = [
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
  "sha2",
 ]
 
@@ -1334,10 +1747,50 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630a4a9b2618348ececfae61a4905f564b817063bf2d66cdfc2ced523fe1d2d4"
 dependencies = [
- "ecdsa",
+ "ecdsa 0.15.1",
  "elliptic-curve 0.12.3",
- "primeorder",
+ "primeorder 0.12.1",
  "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
+ "sha2",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "pcsc"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd833ecf8967e65934c49d3521a175929839bf6d0e497f3bd0d3a2ca08943da"
+dependencies = [
+ "bitflags 2.9.4",
+ "pcsc-sys",
+]
+
+[[package]]
+name = "pcsc-sys"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ef017e15d2e5592a9e39a346c1dbaea5120bab7ed7106b210ef58ebd97003"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -1345,6 +1798,15 @@ name = "pem-rfc7468"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
@@ -1388,6 +1850,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
+dependencies = [
+ "der 0.6.1",
+ "pkcs8 0.9.0",
+ "spki 0.6.0",
+ "zeroize",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1882,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1897,15 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1441,6 +1930,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b54f7131b3dba65a2f414cf5bd25b66d4682e4608610668eae785750ba4c5b2"
 dependencies = [
  "elliptic-curve 0.12.3",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -1518,6 +2016,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "qos_client"
+version = "0.1.0"
+source = "git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905#eee9f4915800d60d21f0eca936173f0a57f31905"
+dependencies = [
+ "aws-nitro-enclaves-nsm-api",
+ "borsh",
+ "p256 0.12.0",
+ "qos_core 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
+ "qos_crypto 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
+ "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
+ "qos_nsm 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
+ "qos_p256 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
+ "rand_core 0.9.3",
+ "rpassword",
+ "serde_json",
+ "ureq",
+ "x509",
+ "yubikey",
+ "zeroize",
+]
+
+[[package]]
 name = "qos_core"
 version = "0.1.0"
 source = "git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98#38db2841cae036eefce0dcb6d0cca80f93a91e98"
@@ -1526,13 +2046,30 @@ dependencies = [
  "borsh",
  "libc",
  "nix",
- "qos_crypto",
- "qos_hex",
- "qos_nsm",
- "qos_p256",
+ "qos_crypto 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
+ "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
+ "qos_nsm 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
+ "qos_p256 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
  "serde",
  "serde_bytes",
  "vsss-rs",
+]
+
+[[package]]
+name = "qos_core"
+version = "0.1.0"
+source = "git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905#eee9f4915800d60d21f0eca936173f0a57f31905"
+dependencies = [
+ "aws-nitro-enclaves-nsm-api",
+ "borsh",
+ "libc",
+ "nix",
+ "qos_crypto 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
+ "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
+ "qos_nsm 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
+ "qos_p256 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
+ "serde",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -1543,7 +2080,18 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
+ "vsss-rs",
+]
+
+[[package]]
+name = "qos_crypto"
+version = "0.1.0"
+source = "git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905#eee9f4915800d60d21f0eca936173f0a57f31905"
+dependencies = [
+ "rand 0.9.2",
+ "sha2",
+ "thiserror 2.0.16",
  "vsss-rs",
 ]
 
@@ -1556,6 +2104,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "qos_hex"
+version = "0.1.0"
+source = "git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905#eee9f4915800d60d21f0eca936173f0a57f31905"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "qos_nsm"
 version = "0.1.0"
 source = "git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98#38db2841cae036eefce0dcb6d0cca80f93a91e98"
@@ -1563,12 +2119,28 @@ dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",
  "borsh",
- "p384",
- "qos_hex",
+ "p384 0.12.0",
+ "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
  "serde_bytes",
  "sha2",
  "webpki",
- "x509-cert",
+ "x509-cert 0.1.0",
+]
+
+[[package]]
+name = "qos_nsm"
+version = "0.1.0"
+source = "git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905#eee9f4915800d60d21f0eca936173f0a57f31905"
+dependencies = [
+ "aws-nitro-enclaves-cose",
+ "aws-nitro-enclaves-nsm-api",
+ "borsh",
+ "p384 0.13.1",
+ "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
+ "serde_bytes",
+ "sha2",
+ "webpki",
+ "x509-cert 0.2.5",
 ]
 
 [[package]]
@@ -1580,9 +2152,24 @@ dependencies = [
  "borsh",
  "hkdf",
  "hmac",
- "p256",
- "qos_hex",
+ "p256 0.12.0",
+ "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
  "rand_core 0.6.4",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
+name = "qos_p256"
+version = "0.1.0"
+source = "git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905#eee9f4915800d60d21f0eca936173f0a57f31905"
+dependencies = [
+ "aes-gcm",
+ "borsh",
+ "hkdf",
+ "hmac",
+ "p256 0.12.0",
+ "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
  "sha2",
  "zeroize",
 ]
@@ -1603,6 +2190,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -1630,8 +2223,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1642,6 +2245,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1665,7 +2278,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1712,11 +2334,11 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "prost",
- "qos_core",
- "qos_crypto",
- "qos_hex",
- "qos_nsm",
- "qos_p256",
+ "qos_core 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
+ "qos_crypto 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
+ "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
+ "qos_nsm 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
+ "qos_p256 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
  "serde",
  "serde_json",
 ]
@@ -1729,13 +2351,22 @@ dependencies = [
  "health_check",
  "host_primitives",
  "prost",
- "qos_core",
+ "qos_core 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
  "reshard_app",
  "serde_json",
  "tokio",
  "tonic",
  "tonic-prost",
  "tonic-reflection",
+]
+
+[[package]]
+name = "reshard_provision"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "dialoguer",
+ "qos_client",
 ]
 
 [[package]]
@@ -1750,6 +2381,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,9 +2398,51 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "094052d5470cbcef561cb848a7209968c9f12dfa6d668f4bca048ac5de51099c"
+dependencies = [
+ "byteorder",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.9.0",
+ "rand_core 0.6.4",
+ "signature 1.6.4",
+ "smallvec",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
  "windows-sys 0.52.0",
 ]
 
@@ -1768,6 +2451,15 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "rustversion"
@@ -1830,6 +2522,15 @@ dependencies = [
  "generic-array 0.14.7",
  "pkcs8 0.10.2",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
  "zeroize",
 ]
 
@@ -1901,7 +2602,7 @@ version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -1938,6 +2639,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,6 +2671,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1971,6 +2689,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2017,6 +2745,12 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
@@ -2055,7 +2789,7 @@ checksum = "6fbb9ed849fede2765386134c64bc8984081e8c8408bc9201b99c6e3143ec5e7"
 dependencies = [
  "hashbrown 0.14.5",
  "rustversion",
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -2099,6 +2833,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,7 +2877,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -2128,6 +2894,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2163,6 +2940,16 @@ checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -2243,7 +3030,7 @@ checksum = "67ac5a8627ada0968acec063a4746bf79588aa03ccb66db2f75d7dce26722a40"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -2383,6 +3170,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2397,6 +3196,47 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "once_cell",
+ "url",
+]
+
+[[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -2437,6 +3277,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.4+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2536,7 +3385,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -2570,12 +3419,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2584,7 +3439,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2603,6 +3458,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -2679,12 +3543,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x509"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3cec94c3999f31341553f358ef55f65fc031291a022cd42ec0ce7219560c76"
+dependencies = [
+ "chrono",
+ "cookie-factory",
 ]
 
 [[package]]
@@ -2697,6 +3583,93 @@ dependencies = [
  "der 0.6.1",
  "flagset",
  "spki 0.6.0",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+dependencies = [
+ "asn1-rs",
+ "base64 0.13.1",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "synstructure 0.13.2",
+]
+
+[[package]]
+name = "yubikey"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10e6fa9476951a9b93d9a31aa5554b5bbac7aafdc5b23e663eb3f9b635c86053"
+dependencies = [
+ "base16ct 0.1.1",
+ "chrono",
+ "cookie-factory",
+ "der-parser",
+ "des",
+ "elliptic-curve 0.12.3",
+ "hmac",
+ "log",
+ "nom",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "p256 0.11.1",
+ "p384 0.11.2",
+ "pbkdf2",
+ "pcsc",
+ "rand_core 0.6.4",
+ "rsa",
+ "secrecy",
+ "sha1",
+ "sha2",
+ "subtle",
+ "uuid",
+ "x509",
+ "x509-parser",
+ "zeroize",
 ]
 
 [[package]]
@@ -2720,6 +3693,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "synstructure 0.13.2",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,6 +3727,39 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,8 +563,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
- "der_derive 0.6.1",
- "flagset",
  "pem-rfc7468 0.6.0",
  "zeroize",
 ]
@@ -576,7 +574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
- "der_derive 0.7.3",
+ "der_derive",
  "flagset",
  "pem-rfc7468 0.7.0",
  "zeroize",
@@ -594,18 +592,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rusticata-macros",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef71ddb5b3a1f53dee24817c8f70dfa1cb29e804c18d88c228d4bc9c86ee3b9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -684,10 +670,10 @@ dependencies = [
  "borsh",
  "clap",
  "futures",
- "qos_core 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
- "qos_crypto 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
- "qos_nsm 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
- "qos_p256 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
+ "qos_core",
+ "qos_crypto",
+ "qos_nsm",
+ "qos_p256",
  "qos_test_primitives",
  "reshard_app",
  "reshard_host",
@@ -1144,7 +1130,7 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "prost",
- "qos_core 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
+ "qos_core",
  "tokio",
  "tonic",
 ]
@@ -1743,18 +1729,6 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630a4a9b2618348ececfae61a4905f564b817063bf2d66cdfc2ced523fe1d2d4"
-dependencies = [
- "ecdsa 0.15.1",
- "elliptic-curve 0.12.3",
- "primeorder 0.12.1",
- "sha2",
-]
-
-[[package]]
-name = "p384"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
@@ -1951,30 +1925,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,16 +1968,16 @@ dependencies = [
 [[package]]
 name = "qos_client"
 version = "0.1.0"
-source = "git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905#eee9f4915800d60d21f0eca936173f0a57f31905"
+source = "git+https://github.com/tkhq/qos.git?rev=0060f65732115322620f094f63d7a81069169148#0060f65732115322620f094f63d7a81069169148"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "borsh",
  "p256 0.12.0",
- "qos_core 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
- "qos_crypto 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
- "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
- "qos_nsm 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
- "qos_p256 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
+ "qos_core",
+ "qos_crypto",
+ "qos_hex",
+ "qos_nsm",
+ "qos_p256",
  "rand_core 0.9.3",
  "rpassword",
  "serde_json",
@@ -2040,34 +1990,16 @@ dependencies = [
 [[package]]
 name = "qos_core"
 version = "0.1.0"
-source = "git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98#38db2841cae036eefce0dcb6d0cca80f93a91e98"
+source = "git+https://github.com/tkhq/qos.git?rev=0060f65732115322620f094f63d7a81069169148#0060f65732115322620f094f63d7a81069169148"
 dependencies = [
  "aws-nitro-enclaves-nsm-api",
  "borsh",
  "libc",
  "nix",
- "qos_crypto 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
- "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
- "qos_nsm 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
- "qos_p256 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
- "serde",
- "serde_bytes",
- "vsss-rs",
-]
-
-[[package]]
-name = "qos_core"
-version = "0.1.0"
-source = "git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905#eee9f4915800d60d21f0eca936173f0a57f31905"
-dependencies = [
- "aws-nitro-enclaves-nsm-api",
- "borsh",
- "libc",
- "nix",
- "qos_crypto 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
- "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
- "qos_nsm 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
- "qos_p256 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
+ "qos_crypto",
+ "qos_hex",
+ "qos_nsm",
+ "qos_p256",
  "serde",
  "serde_bytes",
 ]
@@ -2075,19 +2007,7 @@ dependencies = [
 [[package]]
 name = "qos_crypto"
 version = "0.1.0"
-source = "git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98#38db2841cae036eefce0dcb6d0cca80f93a91e98"
-dependencies = [
- "rand 0.8.5",
- "rand_core 0.6.4",
- "sha2",
- "thiserror 1.0.69",
- "vsss-rs",
-]
-
-[[package]]
-name = "qos_crypto"
-version = "0.1.0"
-source = "git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905#eee9f4915800d60d21f0eca936173f0a57f31905"
+source = "git+https://github.com/tkhq/qos.git?rev=0060f65732115322620f094f63d7a81069169148#0060f65732115322620f094f63d7a81069169148"
 dependencies = [
  "rand 0.9.2",
  "sha2",
@@ -2098,15 +2018,7 @@ dependencies = [
 [[package]]
 name = "qos_hex"
 version = "0.1.0"
-source = "git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98#38db2841cae036eefce0dcb6d0cca80f93a91e98"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "qos_hex"
-version = "0.1.0"
-source = "git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905#eee9f4915800d60d21f0eca936173f0a57f31905"
+source = "git+https://github.com/tkhq/qos.git?rev=0060f65732115322620f094f63d7a81069169148#0060f65732115322620f094f63d7a81069169148"
 dependencies = [
  "serde",
 ]
@@ -2114,62 +2026,30 @@ dependencies = [
 [[package]]
 name = "qos_nsm"
 version = "0.1.0"
-source = "git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98#38db2841cae036eefce0dcb6d0cca80f93a91e98"
-dependencies = [
- "aws-nitro-enclaves-cose",
- "aws-nitro-enclaves-nsm-api",
- "borsh",
- "p384 0.12.0",
- "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
- "serde_bytes",
- "sha2",
- "webpki",
- "x509-cert 0.1.0",
-]
-
-[[package]]
-name = "qos_nsm"
-version = "0.1.0"
-source = "git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905#eee9f4915800d60d21f0eca936173f0a57f31905"
+source = "git+https://github.com/tkhq/qos.git?rev=0060f65732115322620f094f63d7a81069169148#0060f65732115322620f094f63d7a81069169148"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",
  "borsh",
  "p384 0.13.1",
- "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
+ "qos_hex",
  "serde_bytes",
  "sha2",
  "webpki",
- "x509-cert 0.2.5",
+ "x509-cert",
 ]
 
 [[package]]
 name = "qos_p256"
 version = "0.1.0"
-source = "git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98#38db2841cae036eefce0dcb6d0cca80f93a91e98"
+source = "git+https://github.com/tkhq/qos.git?rev=0060f65732115322620f094f63d7a81069169148#0060f65732115322620f094f63d7a81069169148"
 dependencies = [
  "aes-gcm",
  "borsh",
  "hkdf",
  "hmac",
  "p256 0.12.0",
- "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
- "rand_core 0.6.4",
- "sha2",
- "zeroize",
-]
-
-[[package]]
-name = "qos_p256"
-version = "0.1.0"
-source = "git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905#eee9f4915800d60d21f0eca936173f0a57f31905"
-dependencies = [
- "aes-gcm",
- "borsh",
- "hkdf",
- "hmac",
- "p256 0.12.0",
- "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=eee9f4915800d60d21f0eca936173f0a57f31905)",
+ "qos_hex",
  "sha2",
  "zeroize",
 ]
@@ -2177,9 +2057,9 @@ dependencies = [
 [[package]]
 name = "qos_test_primitives"
 version = "0.1.0"
-source = "git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98#38db2841cae036eefce0dcb6d0cca80f93a91e98"
+source = "git+https://github.com/tkhq/qos.git?rev=0060f65732115322620f094f63d7a81069169148#0060f65732115322620f094f63d7a81069169148"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -2334,11 +2214,11 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "prost",
- "qos_core 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
- "qos_crypto 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
- "qos_hex 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
- "qos_nsm 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
- "qos_p256 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
+ "qos_core",
+ "qos_crypto",
+ "qos_hex",
+ "qos_nsm",
+ "qos_p256",
  "serde",
  "serde_json",
 ]
@@ -2351,7 +2231,7 @@ dependencies = [
  "health_check",
  "host_primitives",
  "prost",
- "qos_core 0.1.0 (git+https://github.com/tkhq/qos.git?rev=38db2841cae036eefce0dcb6d0cca80f93a91e98)",
+ "qos_core",
  "reshard_app",
  "serde_json",
  "tokio",
@@ -3572,18 +3452,6 @@ checksum = "ca3cec94c3999f31341553f358ef55f65fc031291a022cd42ec0ce7219560c76"
 dependencies = [
  "chrono",
  "cookie-factory",
-]
-
-[[package]]
-name = "x509-cert"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd27a832a85efcf56cad058e4e3256d1781b927e113a9e37d96916d639e4af7"
-dependencies = [
- "const-oid",
- "der 0.6.1",
- "flagset",
- "spki 0.6.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,6 +2367,7 @@ dependencies = [
  "clap",
  "dialoguer",
  "qos_client",
+ "tempdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ rust.missing_docs = "warn"
 members = [
 	"apps/reshard/app",
 	"apps/reshard/host",
+	"apps/reshard/provision",
 	"common/host_primitives",
 	"common/health_check",
 	"e2e"
@@ -30,6 +31,7 @@ serde_json = { version = "1", default-features = false }
 clap = { version = "4.5", features = ["derive", "env", "std"], default-features = false }
 tempdir = { version = "0.3", default-features = false }
 futures = { version = "0.3", default-features = false }
+dialoguer = { version = "0.12", default-features = false }
 
 # QOS
 qos_core = { git = "https://github.com/tkhq/qos.git", rev = "38db2841cae036eefce0dcb6d0cca80f93a91e98", default-features = false }
@@ -38,6 +40,7 @@ qos_hex = { git = "https://github.com/tkhq/qos.git", rev = "38db2841cae036eefce0
 qos_p256 = { git = "https://github.com/tkhq/qos.git", rev = "38db2841cae036eefce0dcb6d0cca80f93a91e98", default-features = false }
 qos_nsm = { git = "https://github.com/tkhq/qos.git", rev = "38db2841cae036eefce0dcb6d0cca80f93a91e98", default-features = false }
 qos_test_primitives = { git = "https://github.com/tkhq/qos.git", rev = "38db2841cae036eefce0dcb6d0cca80f93a91e98", default-features = false }
+qos_client = { git = "https://github.com/tkhq/qos.git", rev = "eee9f4915800d60d21f0eca936173f0a57f31905", default-features = false }
 
 # Local
 host_primitives = { path = "common/host_primitives" }
@@ -45,3 +48,4 @@ health_check = { path = "common/health_check" }
 codegen = { path = "common/codegen" }
 reshard_app = { path = "apps/reshard/app" }
 reshard_host = { path = "apps/reshard/host" }
+reshard_provision = { path = "apps/reshard/provision" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,13 +34,13 @@ futures = { version = "0.3", default-features = false }
 dialoguer = { version = "0.12", default-features = false }
 
 # QOS
-qos_core = { git = "https://github.com/tkhq/qos.git", rev = "38db2841cae036eefce0dcb6d0cca80f93a91e98", default-features = false }
-qos_crypto = { git = "https://github.com/tkhq/qos.git", rev = "38db2841cae036eefce0dcb6d0cca80f93a91e98", default-features = false }
-qos_hex = { git = "https://github.com/tkhq/qos.git", rev = "38db2841cae036eefce0dcb6d0cca80f93a91e98", default-features = false }
-qos_p256 = { git = "https://github.com/tkhq/qos.git", rev = "38db2841cae036eefce0dcb6d0cca80f93a91e98", default-features = false }
-qos_nsm = { git = "https://github.com/tkhq/qos.git", rev = "38db2841cae036eefce0dcb6d0cca80f93a91e98", default-features = false }
-qos_test_primitives = { git = "https://github.com/tkhq/qos.git", rev = "38db2841cae036eefce0dcb6d0cca80f93a91e98", default-features = false }
-qos_client = { git = "https://github.com/tkhq/qos.git", rev = "eee9f4915800d60d21f0eca936173f0a57f31905", default-features = false }
+qos_core = { git = "https://github.com/tkhq/qos.git", rev = "0060f65732115322620f094f63d7a81069169148", default-features = false }
+qos_crypto = { git = "https://github.com/tkhq/qos.git", rev = "0060f65732115322620f094f63d7a81069169148", default-features = false }
+qos_hex = { git = "https://github.com/tkhq/qos.git", rev = "0060f65732115322620f094f63d7a81069169148", default-features = false }
+qos_p256 = { git = "https://github.com/tkhq/qos.git", rev = "0060f65732115322620f094f63d7a81069169148", default-features = false }
+qos_nsm = { git = "https://github.com/tkhq/qos.git", rev = "0060f65732115322620f094f63d7a81069169148", default-features = false }
+qos_test_primitives = { git = "https://github.com/tkhq/qos.git", rev = "0060f65732115322620f094f63d7a81069169148", default-features = false }
+qos_client = { git = "https://github.com/tkhq/qos.git", rev = "0060f65732115322620f094f63d7a81069169148", default-features = false }
 
 # Local
 host_primitives = { path = "common/host_primitives" }

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ REGISTRY := local
 .PHONY: default
 default: \
 	out/reshard_host/index.json \
-	out/reshard_app/index.json
+	out/reshard_app/index.json \
+	out/reshard_provision/index.json 
 
 out/common/index.json: \
 	images/common/Containerfile
@@ -39,6 +40,15 @@ out/reshard_app/index.json: \
 		Cargo.lock \
 		apps/reshard/app)
 	$(call build,reshard_app)
+
+out/reshard_provision/index.json: \
+	out/common/index.json \
+	images/reshard_provision/Containerfile \
+	$(shell git ls-files \
+		Cargo.toml \
+		Cargo.lock \
+		apps/reshard/provision)
+	$(call build,reshard_provision)
 
 .PHONY: codegen
 codegen: 

--- a/apps/reshard/provision/Cargo.toml
+++ b/apps/reshard/provision/Cargo.toml
@@ -7,5 +7,6 @@ publish = false
 [dependencies]
 clap = { workspace = true }
 dialoguer = { workspace = true }
+tempdir = { workspace = true }
 
 qos_client = { workspace = true, features = ["smartcard"]}

--- a/apps/reshard/provision/Cargo.toml
+++ b/apps/reshard/provision/Cargo.toml
@@ -9,4 +9,4 @@ clap = { workspace = true }
 dialoguer = { workspace = true }
 tempdir = { workspace = true }
 
-qos_client = { workspace = true, features = ["smartcard"]}
+qos_client = { workspace = true, features = ["smartcard"] }

--- a/apps/reshard/provision/Cargo.toml
+++ b/apps/reshard/provision/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "reshard_provision"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+clap = { workspace = true }
+dialoguer = { workspace = true }
+
+qos_client = { workspace = true, features = ["smartcard"]}

--- a/apps/reshard/provision/src/cli.rs
+++ b/apps/reshard/provision/src/cli.rs
@@ -12,15 +12,15 @@ use crate::{run, Config};
     about = "Offline Yubikey provisioning ceremony orchestrator"
 )]
 struct Args {
-    /// Number of members
+    /// Number of operators
     #[arg(long)]
-    members: usize,
+    num_operators: usize,
 
-    /// Keys per member (default: 3)
+    /// Keys per operator (default: 3)
     #[arg(long, default_value_t = 3)]
-    keys_per_member: usize,
+    keys_per_operator: usize,
 
-    /// Output root (member subdirs created inside)
+    /// Output root
     #[arg(long)]
     out: PathBuf,
 
@@ -38,8 +38,8 @@ impl CLI {
     pub fn execute() {
         let args = Args::parse();
         let cfg = Config {
-            members: args.members,
-            keys_per_member: args.keys_per_member,
+            num_operators: args.num_operators,
+            keys_per_operator: args.keys_per_operator,
             out: args.out,
             include_secrets: args.include_secrets,
         };

--- a/apps/reshard/provision/src/cli.rs
+++ b/apps/reshard/provision/src/cli.rs
@@ -16,7 +16,7 @@ struct Args {
     #[arg(long)]
     num_operators: usize,
 
-    /// Keys per operator (default: 3)
+    /// Keys per operator
     #[arg(long, default_value_t = 3)]
     keys_per_operator: usize,
 
@@ -28,8 +28,6 @@ struct Args {
     #[arg(long)]
     include_secrets: bool,
 }
-
-impl Args {}
 
 /// Provision binary command line interface.
 pub struct CLI;

--- a/apps/reshard/provision/src/cli.rs
+++ b/apps/reshard/provision/src/cli.rs
@@ -1,0 +1,51 @@
+//! CLI for reshard provisioning.
+
+use clap::Parser;
+use std::path::PathBuf;
+
+use crate::{run, Config};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "reshard_provision",
+    version,
+    about = "Offline Yubikey provisioning ceremony orchestrator"
+)]
+struct Args {
+    /// Number of members
+    #[arg(long)]
+    members: usize,
+
+    /// Keys per member (default: 3)
+    #[arg(long, default_value_t = 3)]
+    keys_per_member: usize,
+
+    /// Output root (member subdirs created inside)
+    #[arg(long)]
+    out: PathBuf,
+
+    /// Include master *.secret files in output
+    #[arg(long)]
+    include_secrets: bool,
+}
+
+impl Args {}
+
+/// Provision binary command line interface.
+pub struct CLI;
+impl CLI {
+    /// Execute the command line interface.
+    pub fn execute() {
+        let args = Args::parse();
+        let cfg = Config {
+            members: args.members,
+            keys_per_member: args.keys_per_member,
+            out: args.out,
+            include_secrets: args.include_secrets,
+        };
+        if let Err(e) = run(cfg) {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/apps/reshard/provision/src/lib.rs
+++ b/apps/reshard/provision/src/lib.rs
@@ -80,7 +80,7 @@ pub fn run(cfg: Config) -> Result<(), Box<dyn std::error::Error>> {
 
 fn confirm_yes(prompt: &str, default_yes: bool) -> Result<bool, Box<dyn std::error::Error>> {
     Ok(Confirm::with_theme(&ColorfulTheme::default())
-        .with_prompt(format!("{prompt}"))
+        .with_prompt(prompt)
         .default(default_yes)
         .show_default(true)
         .wait_for_newline(true)

--- a/apps/reshard/provision/src/lib.rs
+++ b/apps/reshard/provision/src/lib.rs
@@ -81,7 +81,7 @@ pub fn run(cfg: Config) -> Result<(), Box<dyn std::error::Error>> {
 
 fn confirm_yes(prompt: &str, default_yes: bool) -> Result<bool, Box<dyn std::error::Error>> {
     Ok(Confirm::with_theme(&ColorfulTheme::default())
-        .with_prompt(format!("{prompt} [yes/no]"))
+        .with_prompt(format!("{prompt}"))
         .default(default_yes)
         .show_default(true)
         .wait_for_newline(true)

--- a/apps/reshard/provision/src/lib.rs
+++ b/apps/reshard/provision/src/lib.rs
@@ -37,7 +37,7 @@ pub fn run(cfg: Config) -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        let tmp_dir = TempDir::new("secrets").unwrap();
+        let tmp_dir = TempDir::new("reshard-secrets").unwrap();
         let tmp_secret_path = tmp_dir.path().join(format!("{m}.secret"));
 
         generate_file_key(&tmp_secret_path, &pub_path);
@@ -46,7 +46,7 @@ pub fn run(cfg: Config) -> Result<(), Box<dyn std::error::Error>> {
         for k in 1..=cfg.keys_per_operator {
             let prompt = format!("Please insert yubikey {k} for operator {m}. Are you ready?");
             while !confirm_yes(&prompt, false)? {
-                println!("Oops that wasn't correct. Have you recently 420'd?");
+                println!("Oops that wasn't correct.");
             }
 
             loop {
@@ -71,7 +71,7 @@ pub fn run(cfg: Config) -> Result<(), Box<dyn std::error::Error>> {
             println!("Secret for operator {m} stayed in tmp/secrets and was removed)");
         }
 
-        // tmp_dir drops out of scope here and is therefore removed
+        drop(tmp_dir) // tmp_dir drops out of scope here and is therefore removed but making it explicit
     }
 
     println!("All operator yubikeys provisioned!");

--- a/apps/reshard/provision/src/lib.rs
+++ b/apps/reshard/provision/src/lib.rs
@@ -27,10 +27,9 @@ pub fn run(cfg: Config) -> Result<(), Box<dyn std::error::Error>> {
     for m in 1..=cfg.num_operators {
         let pub_path: PathBuf = cfg.out.join(format!("{m}.pub"));
         if pub_path.exists() {
-            let skip_prompt = format!("Found existing public key for operator {m}. Skip provisioning?");
-            let skip = confirm_yes(
-                &skip_prompt,
-                true)?;
+            let skip_prompt =
+                format!("Found existing public key for operator {m}. Skip provisioning?");
+            let skip = confirm_yes(&skip_prompt, true)?;
 
             if skip {
                 println!("Skipping operator {m}");

--- a/apps/reshard/provision/src/lib.rs
+++ b/apps/reshard/provision/src/lib.rs
@@ -1,0 +1,68 @@
+pub mod cli;
+
+use dialoguer::{theme::ColorfulTheme, Confirm};
+use qos_client::cli::{advanced_provision_yubikey, generate_file_key};
+use std::{fs, path::PathBuf};
+
+/// Public configuration passed in from the CLI (or tests).
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub members: usize,
+    pub keys_per_member: usize,
+    pub out: PathBuf,
+    pub include_secrets: bool,
+}
+
+pub fn run(cfg: Config) -> Result<(), Box<dyn std::error::Error>> {
+    // Ensure output directory exists
+    fs::create_dir_all(&cfg.out)?;
+
+    for m in 1..=cfg.members {
+        let secret_path = cfg.out.join(format!("{m}.secret"));
+        let pub_path: PathBuf = cfg.out.join(format!("{m}.pub"));
+
+        // Generate seed + pub for this member
+        generate_file_key(&secret_path, &pub_path);
+
+        // Provision configured number of yubikeys for this seed
+        for k in 1..=cfg.keys_per_member {
+            let prompt = format!("please insert yubikey {k} for member {m}. are you ready?");
+            while !confirm_yes(&prompt, false)? {
+                println!("oops that wasn't correct. have you recently 420'd?");
+            }
+
+            loop {
+                match advanced_provision_yubikey(&secret_path, None) {
+                    Ok(()) => {
+                        println!("provisioned yubikey {k}, member {m}");
+                        break;
+                    }
+                    Err(e) => {
+                        eprintln!("provisioning failed for yubikey {k}, member {m}, {e:?}");
+                        continue;
+                    }
+                }
+            }
+        }
+
+        if !cfg.include_secrets {
+            let _ = fs::remove_file(&secret_path);
+            println!("removed {}", secret_path.display());
+        } else {
+            println!("kept {}", secret_path.display());
+        }
+    }
+
+    println!("all members provisioned");
+    Ok(())
+}
+
+fn confirm_yes(prompt: &str, default_yes: bool) -> Result<bool, Box<dyn std::error::Error>> {
+    Ok(Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt(prompt.to_string())
+        .default(default_yes)
+        .show_default(true)
+        .wait_for_newline(true)
+        .report(false)
+        .interact()?)
+}

--- a/apps/reshard/provision/src/lib.rs
+++ b/apps/reshard/provision/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 use dialoguer::{theme::ColorfulTheme, Confirm};
 use qos_client::cli::{advanced_provision_yubikey, generate_file_key};
 use std::{fs, path::PathBuf};
+use tempdir::TempDir;
 
 /// Public configuration passed in from the CLI (or tests).
 #[derive(Debug, Clone)]
@@ -18,11 +19,12 @@ pub fn run(cfg: Config) -> Result<(), Box<dyn std::error::Error>> {
     fs::create_dir_all(&cfg.out)?;
 
     for m in 1..=cfg.members {
-        let secret_path = cfg.out.join(format!("{m}.secret"));
+        let tmp_dir = TempDir::new("secrets").unwrap();
+        let tmp_secret_path = tmp_dir.path().join(format!("{m}.secret"));
         let pub_path: PathBuf = cfg.out.join(format!("{m}.pub"));
 
         // Generate seed + pub for this member
-        generate_file_key(&secret_path, &pub_path);
+        generate_file_key(&tmp_secret_path, &pub_path);
 
         // Provision configured number of yubikeys for this seed
         for k in 1..=cfg.keys_per_member {
@@ -32,7 +34,7 @@ pub fn run(cfg: Config) -> Result<(), Box<dyn std::error::Error>> {
             }
 
             loop {
-                match advanced_provision_yubikey(&secret_path, None) {
+                match advanced_provision_yubikey(&tmp_secret_path, None) {
                     Ok(()) => {
                         println!("provisioned yubikey {k}, member {m}");
                         break;
@@ -45,12 +47,15 @@ pub fn run(cfg: Config) -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        if !cfg.include_secrets {
-            let _ = fs::remove_file(&secret_path);
-            println!("removed {}", secret_path.display());
+        if cfg.include_secrets {
+            let secret_path = cfg.out.join(format!("{m}.secret"));
+            fs::copy(&tmp_secret_path, &secret_path)?;
+            println!("kept {}", secret_path.display())
         } else {
-            println!("kept {}", secret_path.display());
+            println!("secret for member {m} stayed in tmp/secrets and was removed)");
         }
+
+        // tmp_dir drops out of scope here and is therefore removed
     }
 
     println!("all members provisioned");

--- a/apps/reshard/provision/src/main.rs
+++ b/apps/reshard/provision/src/main.rs
@@ -1,0 +1,5 @@
+use reshard_provision::cli::CLI;
+
+fn main() {
+    CLI::execute()
+}

--- a/images/reshard_provision/Containerfile
+++ b/images/reshard_provision/Containerfile
@@ -31,3 +31,4 @@ EOF
 
 FROM scratch AS package
 COPY --from=base /rootfs/. .
+ENTRYPOINT ["/reshard_provision"]

--- a/images/reshard_provision/Containerfile
+++ b/images/reshard_provision/Containerfile
@@ -1,0 +1,33 @@
+FROM stagex/pallet-rust:sx2025.06.0@sha256:740b9ed5f2a897d45cafdc806976d84231aa50a64998610750b42a48f8daacab AS rust
+FROM stagex/pcsc-lite:sx2024.03.0@sha256:e720e1795706c7c8c1db14bf730b10521e3ff42e4bed90addc590f7446aac8af AS pcsc-lite
+
+FROM scratch AS base
+COPY --from=pcsc-lite . /
+COPY --from=rust . /
+
+# Rust configuration
+ENV RUSTFLAGS='-C target-feature=+crt-static'
+ENV CARGOFLAGS='--target x86_64-unknown-linux-musl --no-default-features --locked --release'
+
+# Directory for Rust artifacts
+ENV RELEASE_DIR=/target/x86_64-unknown-linux-musl/release
+
+ENV PCSC_LIB_NAME=static=pcsclite
+
+# Load Rust sources
+ADD . .
+
+# pre-fetch all workspace deps; we need to them to build with `--network=none`
+RUN cargo -V && rustc -V && cargo fetch
+RUN pkg-config --modversion libpcsclite
+
+WORKDIR /apps/reshard/provision
+RUN --network=none <<-EOF
+    set -eu
+    cargo build ${CARGOFLAGS}
+    mkdir -p /rootfs
+    mv ${RELEASE_DIR}/reshard_provision /rootfs/
+EOF
+
+FROM scratch AS package
+COPY --from=base /rootfs/. .


### PR DESCRIPTION
- Add `apps/reshard/provision` CLI to orchestrate an offline YubiKey provisioning ceremony using qos_client (smartcard); flags: --num-operators, --keys-per-operator --out, --include-secrets.

- For each operator generates {m}.secret/{m}.pub, provisions the requested number of keys with interactive dialoguer prompts and retry-on-failure; secrets are removed by default unless --include-secrets.

Waiting on this PR to update the qos dependencies https://github.com/tkhq/qos/pull/581